### PR TITLE
Ensure that hiddenMenuOffset prop respects the menuPosition multiplie…

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ export default class SideMenu extends React.Component {
     const left: Animated.Value = new Animated.Value(
       props.isOpen
         ? props.openMenuOffset * initialMenuPositionMultiplier
-        : props.hiddenMenuOffset,
+        : props.hiddenMenuOffset * initialMenuPositionMultiplier
     );
 
     this.onLayoutChange = this.onLayoutChange.bind(this);


### PR DESCRIPTION
When using menu in RTL mode or with `end|right` position, the offset should be calculated correctly.

This commit ensures that the initialMenuMultiplier is used to adjust the offset depending on the menuPosition.