### PR TITLE
Add a prop that allows us to render the drawer components children only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ menu is hidden |
 | animationStyle | none | (Function -> Object) | Function that accept 1 argument (value) and return an object: <br /> - `value` you should use at the place you need current value of animated parameter (left offset of content view) |
 | bounceBackOnOverdraw | true | boolean | when true, content view will bounce back to openMenuOffset when dragged further |
 | autoClosing | true | boolean | When true, menu close automatically as soon as an event occurs |
+| visible | true | boolean | When true, drawer gets visible, when false drawer just renders children and draw is unusable |
 
 ### FAQ
 

--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ type Props = {
   onStartShouldSetResponderCapture: Function,
   isOpen: bool,
   bounceBackOnOverdraw: bool,
-  autoClosing: bool
+  autoClosing: bool,
+  visible: bool,
 };
 
 type Event = {
@@ -203,18 +204,19 @@ export default class SideMenu extends React.Component {
       );
     }
 
+    const { visible } = this.props;
     const { width, height, left } = this.state; 
     const ref = sideMenu => (this.sideMenu = sideMenu);
-    const style = [
+    // If the drawer is not visible, then we dont want to render the animation styles.
+    const style = visible ? [
       styles.frontView,
-      { width, height, },
       this.props.animationStyle(left),
-    ];
-
+    ] : [styles.containerWhenNotVisible];
     return (
       <Animated.View style={style} ref={ref} {...this.responder.panHandlers}>
         {this.props.children}
-        {overlay}
+        {/* overlay only when visible */}
+        {visible && overlay}
       </Animated.View>
     );
   }
@@ -308,6 +310,7 @@ export default class SideMenu extends React.Component {
   }
 
   render(): React.Element<void, void> {
+    const { visible } = this.props;
     const boundryStyle = this.getBoundryStyleByDirection();
 
     const menu = (
@@ -318,10 +321,10 @@ export default class SideMenu extends React.Component {
 
     return (
       <View
-        style={styles.container}
+        style={[visible && styles.containerWhenVisible, !visible && styles.containerWhenNotVisible]}
         onLayout={this.onLayoutChange}
       >
-        {menu}
+        {visible && menu}
         {this.getContentView()}
       </View>
     );
@@ -347,6 +350,7 @@ SideMenu.propTypes = {
   isOpen: PropTypes.bool,
   bounceBackOnOverdraw: PropTypes.bool,
   autoClosing: PropTypes.bool,
+  visible: PropTypes.bool,
 };
 
 SideMenu.defaultProps = {
@@ -376,4 +380,5 @@ SideMenu.defaultProps = {
   isOpen: false,
   bounceBackOnOverdraw: true,
   autoClosing: true,
+  visible: true,
 };

--- a/styles.js
+++ b/styles.js
@@ -11,9 +11,15 @@ const absoluteStretch = {
 };
 
 export default StyleSheet.create({
-  container: {
+  containerWhenVisible: {
     ...absoluteStretch,
     justifyContent: 'center',
+  },
+  containerWhenNotVisible: {
+    flex: 1,
+    width: '100%',
+    height: '100%',
+    position: 'relative',
   },
   menu: {
     ...absoluteStretch,
@@ -21,6 +27,8 @@ export default StyleSheet.create({
   frontView: {
     flex: 1,
     position: 'absolute',
+    width: '100%',
+    height: '100%',
     left: 0,
     top: 0,
     backgroundColor: 'transparent',


### PR DESCRIPTION
This allows us to essentially have a drawer in the React hierarchy permenantly, but not alway have the drawer functioning.
Useful for web layouts where a Drawer may not be used at desktop size, however we dont want to re-render the entire React tree.