### PR TITLE
[bugfix]: IOS 9 Safari and other older browsers consistently overflow…

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -1,9 +1,13 @@
 // @flow
 
-import { StyleSheet } from 'react-native';
+import { StyleSheet, Platform } from 'react-native';
+
+// Prevent IOS 9 Safari and some older browsers from overflowing 
+// the body content after drawer opens/closes.
+const position = Platform.OS === 'web' ? 'fixed' : 'absolute'; 
 
 const absoluteStretch = {
-  position: 'absolute',
+  position,
   top: 0,
   left: 0,
   bottom: 0,


### PR DESCRIPTION
…ed the body container when the drawer component closed and opened.

- change `absolute` position to be `fixed` position on top level container when platform is WEB.